### PR TITLE
Removed the navbar from the splash panel, fixed minor bugs

### DIFF
--- a/frontend/src/components/app.js
+++ b/frontend/src/components/app.js
@@ -16,23 +16,22 @@ import SplashContainer from './session/splash_container';
 
 const App = () => (
   <div>
-    <NavBarContainer />
     <Switch>
       <AuthRoute exact path='/login' component={Login} />
       <AuthRoute exact path='/signup' component={Register} />
       <Route path="/splash" component={SplashContainer} />
-      {/* <Route path="/" component={NavBarContainer} /> */}
+      <ProtectedRoute path="/" component={NavBarContainer} />
     </Switch>
     <img className="backdrop" alt="backdrop" src="backdrop.png"/>
     <Switch>
       <ProtectedRoute exact path='/panels/liked' component={LikedIndexContainer} />
       <ProtectedRoute exact path='/panels/authored' component={AuthoredIndexContainer} />
       <ProtectedRoute exact path="/" component={MainIndexContainer} />
-      <Route exact path='/users/:userId' component={UserProfile} />
+      <ProtectedRoute exact path='/users/:userId' component={UserProfile} />
       <ProtectedRoute exact path="/roots/new" component={createPanelContainer} />
       <ProtectedRoute path="/panels/:panelId/branch" component={branchPanelContainer} />
       <ProtectedRoute path="/panels/:panelId/edit" component={editPanelContainer} />
-      <Route path="/panels/:panelId" component={PanelShow} />
+      <ProtectedRoute path="/panels/:panelId" component={PanelShow} />
     </Switch>
   </div>
 );

--- a/frontend/src/components/infoModal/infoModal.jsx
+++ b/frontend/src/components/infoModal/infoModal.jsx
@@ -27,10 +27,7 @@ class InfoModal extends React.Component{
 
   
   componentDidMount(){
-    this.listen = this.props.history.listen(location => {
-      console.log(location.pathname, 'hey this is the location')
-      console.log(this.props.isAuthenticated)
-      if (location.pathname === '/' && this.props.isAuthenticated === true && this.props.showInfoModal === true){
+      if (this.props.location.pathname === '/' && this.props.isAuthenticated === true && this.props.showInfoModal === true){
         if(this.props.currentUser.username === 'demo' || this.props.currentUser.authoredRoots.length === 0){
           this.indexInfo = { text: [
             'Welcome to Offshoot!',
@@ -57,7 +54,6 @@ class InfoModal extends React.Component{
           this.loadModal(this.indexInfo);
         }
       } 
-    })
   }
 
   loadModal(modalInfoToLoad){

--- a/frontend/src/components/panel/show/panel_show.jsx
+++ b/frontend/src/components/panel/show/panel_show.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import CommentsIndex from '../comments/comments_index';
-import { fetchPanel } from '../../../actions/panel_actions';
+import { fetchPanel, clearPanelState } from '../../../actions/panel_actions';
 import { useSwipeable, Swipeable } from 'react-swipeable';
 
 import { Link } from 'react-router-dom';
@@ -19,6 +19,9 @@ export class PanelShow extends Component {
 
     componentDidMount() {
         this.props.fetchPanel(this.props.match.params.panelId);
+    }
+    componentWillUnmount(){
+        this.props.clearPanelState();
     }
 
     handleSwipe() {
@@ -76,7 +79,8 @@ const mapStateToProps = (state, ownProps) => ({
 })
 
 const mapDispatchToProps = (dispatch) => ({
-    fetchPanel: (panelId) => dispatch(fetchPanel(panelId))
+    fetchPanel: (panelId) => dispatch(fetchPanel(panelId)),
+    clearPanelState: () => dispatch(clearPanelState())
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(PanelShow);

--- a/frontend/src/components/session/login_form.jsx
+++ b/frontend/src/components/session/login_form.jsx
@@ -36,9 +36,8 @@ class LoginForm extends React.Component {
       email: this.state.email,
       password: this.state.password
     };
-    this.props.login(user).then(() => {
-        this.props.history.push('/');     
-    });
+    this.props.login(user)
+
   }
 
   renderErrors() {

--- a/frontend/src/components/session/signup_form.jsx
+++ b/frontend/src/components/session/signup_form.jsx
@@ -39,9 +39,7 @@ class SignupForm extends React.Component {
       password2: this.state.password2
     };
 
-    this.props.signup(user, this.props.history).then(()=> {
-      this.props.history.push('/')
-    });
+    this.props.signup(user, this.props.history)
   }
 
   renderErrors() {

--- a/frontend/src/reducers/ui_reducer.js
+++ b/frontend/src/reducers/ui_reducer.js
@@ -5,7 +5,9 @@ import {
     SHOW_INFO_MODAL,
     HIDE_INFO_MODAL
 } from "../actions/ui_actions";
-
+import {
+    RECEIVE_USER_LOGOUT
+} from "../actions/session_actions"
 const initialState = {
     currentModal: null,
     showInfoModal: true
@@ -14,7 +16,6 @@ const initialState = {
 const uiReducer = (state = initialState, action) => {
     Object.freeze(state);
     let newState = Object.assign({}, state)
-
     switch (action.type) {
         case RECEIVE_CURRENT_MODAL:
             newState.currentModal = action.currentModal;
@@ -28,6 +29,9 @@ const uiReducer = (state = initialState, action) => {
             newState.currentModal = null;
             return newState;
         case SHOW_INFO_MODAL:
+            newState.showInfoModal = true;
+            return newState;
+        case RECEIVE_USER_LOGOUT:
             newState.showInfoModal = true;
             return newState;
         case HIDE_INFO_MODAL:


### PR DESCRIPTION
Reverted the navbar changes making it only show up once logged in. 
Added a protected route for panel show to prevent crashing. 
Changed the modal info and fixed the bug that would cuase users to get pushed to index even if the information was incorrect. 
Panel show page now clears state on unmounting. 