### PR TITLE
Fixed the icon credit

### DIFF
--- a/frontend/src/components/main/index/conditional_Index.jsx
+++ b/frontend/src/components/main/index/conditional_Index.jsx
@@ -125,7 +125,7 @@ class ConditionalIndex extends React.Component {
       <div className="panel-index">
         {this.state.panels}
         {/* {this.state.panels.length === 0 ? <div>{`${this.props.indexType} more panels!`}</div> : ''} */}
-        <span>Icon credit</span>
+        {Object.keys(this.state.panels).length > 0 ? <span className="footer-text"><div>Leaf Icons made by <a href="https://www.flaticon.com/authors/freepik" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a></div></span> : ''}
       </div>
     );
   }

--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -147,4 +147,8 @@ h1 {
             justify-self: flex-end;
         }
     }
+    .footer-text{
+        margin-top: 50px;
+        color: $darkest-primary;
+    }
 }


### PR DESCRIPTION
Fixed the icon credit text to only show after panels have rendered, crediting the author of the leaf icons from desktop view. 